### PR TITLE
Fix wrong component reference in activities-block callToAction

### DIFF
--- a/src/components/content-blocks/activities-block.json
+++ b/src/components/content-blocks/activities-block.json
@@ -17,7 +17,7 @@
     "callToAction": {
       "type": "component",
       "repeatable": false,
-      "component": "general.block-properties"
+      "component": "general.call-to-action"
     },
     "initialItems": {
       "type": "integer"


### PR DESCRIPTION
## Summary

- `callToAction` in `activities-block.json` was referencing `general.block-properties` instead of `general.call-to-action`
- This caused the Strapi admin panel to throw `TypeError: Cannot read properties of undefined (reading 'attributes')` when rendering pages that include the activities block

## Test plan

- Open a page in the Strapi admin that uses the activities block — no more JS error in the console