### PR TITLE
Fix Strapi v5 admin crash by renaming colliding dynamic-zone fields

### DIFF
--- a/src/components/content-blocks/hero-block.json
+++ b/src/components/content-blocks/hero-block.json
@@ -9,12 +9,12 @@
     "subtitle": {
       "type": "string"
     },
-    "callToAction": {
+    "heroCta": {
       "type": "component",
       "repeatable": true,
       "component": "general.button"
     },
-    "variant": {
+    "heroVariant": {
       "type": "enumeration",
       "enum": [
         "default",
@@ -45,7 +45,7 @@
         "audios"
       ]
     },
-    "title": {
+    "heroTitle": {
       "type": "richtext"
     }
   }

--- a/src/components/content-blocks/text-image-block.json
+++ b/src/components/content-blocks/text-image-block.json
@@ -23,7 +23,7 @@
         "audios"
       ]
     },
-    "variant": {
+    "layout": {
       "type": "enumeration",
       "enum": [
         "default",


### PR DESCRIPTION
## Summary

Fixes the recurring `TypeError: Cannot read properties of undefined (reading 'attributes')` error in the Strapi admin that hits intermittently on any page using the `blocks` dynamic zone.

## Root cause

[Strapi issue #9150](https://github.com/strapi/strapi/issues/9150) — when two components in the same dynamic zone share an attribute name with different schemas, Strapi's schema reducer overwrites entries and the admin's `formatEditLayout` later reads `undefined.attributes`.

Three collisions existed in the `blocks` dynamic zone:
- `title`: `hero-block` is `richtext`; 13 other blocks are `string`
- `callToAction`: `hero-block` is repeatable → `general.button`; 10 other blocks are non-repeatable → `general.call-to-action`
- `variant`: `divider`, `hero-block`, and `text-image-block` each have different enum values

## Renames

| Component | Old name | New name |
|---|---|---|
| `hero-block` | `title` (richtext) | `heroTitle` |
| `hero-block` | `callToAction` (repeatable → `general.button`) | `heroCta` |
| `hero-block` | `variant` (enum default/large/simple) | `heroVariant` |
| `text-image-block` | `variant` (enum default/reversed) | `layout` |

The `divider.variant` is left as-is since with the other two renamed it no longer collides with anything.

## ⚠️ Breaking changes

1. **Database**: Strapi will drop the old columns and create the renamed ones on next startup. Existing values in `hero-block.title`, `hero-block.callToAction`, `hero-block.variant`, and `text-image-block.variant` in production **will be lost**.
2. **Frontend**: The consumer repo (`scoutinglommel.be`) will need its GraphQL/REST queries updated to read the new field names. Coordinate that change separately.

## Test plan

- [ ] CI build (`pnpm build`) passes
- [ ] After Railway deploy, open the Strapi admin and load a few pages with the `blocks` dynamic zone (`home-page`, `info-page`, `groups-page`, `articles-page`) — confirm the edit view loads without the `attributes` console error
- [ ] Add and save a hero-block and a text-image-block to confirm the renamed fields appear and persist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal naming conventions for component configuration fields across hero and text-image content blocks to improve consistency and clarity in the authoring experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Scouting-Lommel/admin.scoutinglommel.be/pull/64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->