### PR TITLE
Namespace all content-block field names with block-specific prefixes

### DIFF
--- a/src/components/content-blocks/activities-block.json
+++ b/src/components/content-blocks/activities-block.json
@@ -6,20 +6,20 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "activitiesTitle": {
       "type": "string"
     },
-    "blockProperties": {
+    "activitiesBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "callToAction": {
+    "activitiesCallToAction": {
       "type": "component",
       "repeatable": false,
       "component": "general.call-to-action"
     },
-    "initialItems": {
+    "activitiesInitialItems": {
       "type": "integer"
     }
   }

--- a/src/components/content-blocks/articles-block.json
+++ b/src/components/content-blocks/articles-block.json
@@ -6,15 +6,15 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "articlesTitle": {
       "type": "string"
     },
-    "blockProperties": {
+    "articlesBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "callToAction": {
+    "articlesCallToAction": {
       "type": "component",
       "repeatable": false,
       "component": "general.call-to-action"

--- a/src/components/content-blocks/calendar-block.json
+++ b/src/components/content-blocks/calendar-block.json
@@ -6,15 +6,15 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "calendarTitle": {
       "type": "string"
     },
-    "blockProperties": {
+    "calendarBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "callToAction": {
+    "calendarCallToAction": {
       "type": "component",
       "repeatable": false,
       "component": "general.call-to-action"

--- a/src/components/content-blocks/divider.json
+++ b/src/components/content-blocks/divider.json
@@ -7,7 +7,7 @@
   },
   "options": {},
   "attributes": {
-    "variant": {
+    "dividerVariant": {
       "type": "enumeration",
       "enum": [
         "default",

--- a/src/components/content-blocks/events-block.json
+++ b/src/components/content-blocks/events-block.json
@@ -6,21 +6,21 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "eventsTitle": {
       "type": "string",
       "required": true
     },
-    "initialItems": {
+    "eventsInitialItems": {
       "type": "integer",
       "default": 3,
       "required": true
     },
-    "blockProperties": {
+    "eventsBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "callToAction": {
+    "eventsCallToAction": {
       "type": "component",
       "repeatable": false,
       "component": "general.call-to-action"

--- a/src/components/content-blocks/faq-block.json
+++ b/src/components/content-blocks/faq-block.json
@@ -6,7 +6,7 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "faqTitle": {
       "type": "string"
     },
     "faqItems": {
@@ -14,12 +14,12 @@
       "relation": "oneToMany",
       "target": "api::faq-item.faq-item"
     },
-    "blockProperties": {
+    "faqBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "bottomText": {
+    "faqBottomText": {
       "type": "richtext"
     }
   }

--- a/src/components/content-blocks/files-block.json
+++ b/src/components/content-blocks/files-block.json
@@ -6,10 +6,10 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "filesTitle": {
       "type": "string"
     },
-    "blockProperties": {
+    "filesBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"

--- a/src/components/content-blocks/gallery-block.json
+++ b/src/components/content-blocks/gallery-block.json
@@ -6,14 +6,14 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "galleryTitle": {
       "type": "string"
     },
-    "initialItems": {
+    "galleryInitialItems": {
       "type": "integer",
       "default": 6
     },
-    "images": {
+    "galleryImages": {
       "type": "media",
       "multiple": true,
       "required": false,
@@ -24,12 +24,12 @@
         "audios"
       ]
     },
-    "blockProperties": {
+    "galleryBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "callToAction": {
+    "galleryCallToAction": {
       "type": "component",
       "repeatable": false,
       "component": "general.call-to-action"

--- a/src/components/content-blocks/groups-block.json
+++ b/src/components/content-blocks/groups-block.json
@@ -6,20 +6,20 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "groupsTitle": {
       "type": "string"
     },
-    "groups": {
+    "groupsItems": {
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::group.group"
     },
-    "blockProperties": {
+    "groupsBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "callToAction": {
+    "groupsCallToAction": {
       "type": "component",
       "repeatable": false,
       "component": "general.call-to-action"

--- a/src/components/content-blocks/hero-block.json
+++ b/src/components/content-blocks/hero-block.json
@@ -6,15 +6,18 @@
   },
   "options": {},
   "attributes": {
-    "subtitle": {
+    "heroTitle": {
+      "type": "richtext"
+    },
+    "heroSubtitle": {
       "type": "string"
     },
-    "callToAction": {
+    "heroCta": {
       "type": "component",
       "repeatable": true,
       "component": "general.button"
     },
-    "variant": {
+    "heroVariant": {
       "type": "enumeration",
       "enum": [
         "default",
@@ -23,18 +26,18 @@
       ],
       "default": "default"
     },
-    "socialsCta": {
+    "heroSocialsCta": {
       "displayName": "SocialsCta",
       "type": "component",
       "repeatable": false,
       "component": "general.socials-cta"
     },
-    "yearTheme": {
+    "heroYearTheme": {
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::year-theme.year-theme"
     },
-    "bgImage": {
+    "heroBgImage": {
       "type": "media",
       "multiple": false,
       "required": false,
@@ -44,9 +47,6 @@
         "videos",
         "audios"
       ]
-    },
-    "title": {
-      "type": "richtext"
     }
   }
 }

--- a/src/components/content-blocks/leaders-block.json
+++ b/src/components/content-blocks/leaders-block.json
@@ -6,15 +6,15 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "leadersTitle": {
       "type": "string"
     },
-    "blockProperties": {
+    "leadersBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "callToAction": {
+    "leadersCallToAction": {
       "type": "component",
       "repeatable": false,
       "component": "general.call-to-action"

--- a/src/components/content-blocks/map-block.json
+++ b/src/components/content-blocks/map-block.json
@@ -6,19 +6,19 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "mapTitle": {
       "type": "string"
     },
-    "blockProperties": {
+    "mapBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "location": {
+    "mapLocation": {
       "type": "customField",
       "customField": "plugin::google-maps.location-picker"
     },
-    "mapsQuery": {
+    "mapQuery": {
       "type": "string"
     }
   }

--- a/src/components/content-blocks/policy-block.json
+++ b/src/components/content-blocks/policy-block.json
@@ -6,10 +6,10 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "policyTitle": {
       "type": "string"
     },
-    "sections": {
+    "policySections": {
       "type": "component",
       "repeatable": true,
       "component": "general.policy-section"

--- a/src/components/content-blocks/tarifs-block.json
+++ b/src/components/content-blocks/tarifs-block.json
@@ -6,20 +6,20 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "tarifsTitle": {
       "type": "string"
     },
-    "tarifs": {
+    "tarifsItems": {
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::tarif.tarif"
     },
-    "blockProperties": {
+    "tarifsBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "callToAction": {
+    "tarifsCallToAction": {
       "type": "component",
       "repeatable": false,
       "component": "general.call-to-action"

--- a/src/components/content-blocks/text-image-block.json
+++ b/src/components/content-blocks/text-image-block.json
@@ -6,13 +6,13 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "textImageTitle": {
       "type": "string"
     },
-    "content": {
+    "textImageContent": {
       "type": "richtext"
     },
-    "images": {
+    "textImageImages": {
       "type": "media",
       "multiple": true,
       "required": false,
@@ -23,7 +23,7 @@
         "audios"
       ]
     },
-    "variant": {
+    "textImageLayout": {
       "type": "enumeration",
       "enum": [
         "default",
@@ -31,17 +31,17 @@
       ],
       "default": "default"
     },
-    "ctaButton": {
+    "textImageCtaButton": {
       "type": "component",
       "repeatable": false,
       "component": "general.button"
     },
-    "blockProperties": {
+    "textImageBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "callToAction": {
+    "textImageCallToAction": {
       "type": "component",
       "repeatable": false,
       "component": "general.call-to-action"

--- a/src/components/content-blocks/year-theme-block.json
+++ b/src/components/content-blocks/year-theme-block.json
@@ -6,15 +6,15 @@
   },
   "options": {},
   "attributes": {
-    "title": {
+    "yearThemeTitle": {
       "type": "string"
     },
-    "blockProperties": {
+    "yearThemeBlockProperties": {
       "type": "component",
       "repeatable": false,
       "component": "general.block-properties"
     },
-    "callToAction": {
+    "yearThemeCallToAction": {
       "type": "component",
       "repeatable": false,
       "component": "general.call-to-action"


### PR DESCRIPTION
## Summary

Every field in every content-block component is now prefixed with the block's camelCase name (e.g. `title` → `activitiesTitle`, `callToAction` → `galleryCallToAction`). This makes all field names globally unique across the `blocks` dynamic zone.

## Why

Strapi's admin schema reducer uses field names as keys when processing dynamic zones. When two components share a field name with different schemas (e.g. `hero-block.title` is `richtext`, all others are `string`; `hero-block.callToAction` is a repeatable `general.button`, all others are non-repeatable `general.call-to-action`), the reducer overwrites entries and `formatEditLayout` later reads `undefined.attributes`, crashing the admin ([strapi/strapi#9150](https://github.com/strapi/strapi/issues/9150)).

Fixing only the conflicting fields (PR #63, #64) resolves today's bugs but doesn't prevent future collisions as the codebase grows. This PR makes the convention proofed going forward.

## Complete rename map

| Block | Old name | New name |
|---|---|---|
| activities-block | title | activitiesTitle |
| activities-block | blockProperties | activitiesBlockProperties |
| activities-block | callToAction | activitiesCallToAction |
| activities-block | initialItems | activitiesInitialItems |
| articles-block | title | articlesTitle |
| articles-block | blockProperties | articlesBlockProperties |
| articles-block | callToAction | articlesCallToAction |
| calendar-block | title | calendarTitle |
| calendar-block | blockProperties | calendarBlockProperties |
| calendar-block | callToAction | calendarCallToAction |
| divider | variant | dividerVariant |
| events-block | title | eventsTitle |
| events-block | initialItems | eventsInitialItems |
| events-block | blockProperties | eventsBlockProperties |
| events-block | callToAction | eventsCallToAction |
| faq-block | title | faqTitle |
| faq-block | blockProperties | faqBlockProperties |
| faq-block | bottomText | faqBottomText |
| files-block | title | filesTitle |
| files-block | blockProperties | filesBlockProperties |
| gallery-block | title | galleryTitle |
| gallery-block | initialItems | galleryInitialItems |
| gallery-block | images | galleryImages |
| gallery-block | blockProperties | galleryBlockProperties |
| gallery-block | callToAction | galleryCallToAction |
| groups-block | title | groupsTitle |
| groups-block | groups | groupsItems |
| groups-block | blockProperties | groupsBlockProperties |
| groups-block | callToAction | groupsCallToAction |
| hero-block | title | heroTitle |
| hero-block | subtitle | heroSubtitle |
| hero-block | callToAction | heroCta |
| hero-block | variant | heroVariant |
| hero-block | socialsCta | heroSocialsCta |
| hero-block | yearTheme | heroYearTheme |
| hero-block | bgImage | heroBgImage |
| leaders-block | title | leadersTitle |
| leaders-block | blockProperties | leadersBlockProperties |
| leaders-block | callToAction | leadersCallToAction |
| map-block | title | mapTitle |
| map-block | blockProperties | mapBlockProperties |
| map-block | location | mapLocation |
| map-block | mapsQuery | mapQuery |
| policy-block | title | policyTitle |
| policy-block | sections | policySections |
| tarifs-block | title | tarifsTitle |
| tarifs-block | tarifs | tarifsItems |
| tarifs-block | blockProperties | tarifsBlockProperties |
| tarifs-block | callToAction | tarifsCallToAction |
| text-image-block | title | textImageTitle |
| text-image-block | content | textImageContent |
| text-image-block | images | textImageImages |
| text-image-block | variant | textImageLayout |
| text-image-block | ctaButton | textImageCtaButton |
| text-image-block | blockProperties | textImageBlockProperties |
| text-image-block | callToAction | textImageCallToAction |
| year-theme-block | title | yearThemeTitle |
| year-theme-block | blockProperties | yearThemeBlockProperties |
| year-theme-block | callToAction | yearThemeCallToAction |

## ⚠️ Breaking changes

1. **Database**: Strapi drops old columns and creates renamed ones on next startup — existing field data will be lost.
2. **Frontend** (`scoutinglommel.be`): A companion PR updating all GraphQL fragments and components must be merged before/alongside this one. **Do not deploy this to production until the frontend PR is also ready.**

## Test plan

- [ ] CI build passes
- [ ] After deploy (with frontend PR also merged), admin edit views load without `attributes` console errors
- [ ] Hero-block, text-image-block, gallery-block, and map-block forms render and save correctly with the renamed fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized naming conventions across all content block attributes to ensure consistency throughout the system. Implemented block-specific naming patterns for attributes including titles, properties, and call-to-action elements across multiple content block types. These internal structural improvements enhance system organization and maintainability while preserving all existing functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Scouting-Lommel/admin.scoutinglommel.be/pull/65)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->