### PR TITLE
docs: update documentation for TypeScript, pnpm, and Coolify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,10 @@ Scouting Lommel website backend — Strapi v5 CMS with MySQL, deployed on Heroku
 │   ├── api/          # 25 content-type modules ← MAIN CODE
 │   ├── components/   # 29 reusable component schemas
 │   ├── extensions/   # Plugin overrides (users-permissions)
-│   └── index.js      # Bootstrap file (empty)
+│   └── index.ts      # Bootstrap file (empty)
 ├── .github/workflows/  # CI pipeline
 ├── package.json
+├── tsconfig.json     # TypeScript configuration
 └── README.md
 ```
 
@@ -30,11 +31,11 @@ Scouting Lommel website backend — Strapi v5 CMS with MySQL, deployed on Heroku
 |------|----------|-------|
 | Content model (what data exists) | `src/api/*/content-types/*/schema.json` | 25 types |
 | Page structure (dynamic zones) | `src/components/content-blocks/` | 16 block types |
-| Admin customization | `src/admin/app.js` | Locales, bootstrap |
-| Plugin config | `config/plugins.js` | Cloudinary + Google Maps |
-| Security/CSP headers | `config/middlewares.js` | Custom CSP for external services |
+| Admin customization | `src/admin/app.ts` | Locales, bootstrap |
+| Plugin config | `config/plugins.ts` | Cloudinary + Google Maps |
+| Security/CSP headers | `config/middlewares.ts` | Custom CSP for external services |
 | User schema extension | `src/extensions/users-permissions/` | Leader relation added |
-| CI/CD | `.github/workflows/ci.yml` | pnpm, Node 20 |
+| CI/CD | `.github/workflows/ci.yml` | pnpm, Node 22 |
 
 ## CONVENTIONS
 - All controllers/services/routes use Strapi v5 `factories` boilerplate (no custom logic)
@@ -44,6 +45,7 @@ Scouting Lommel website backend — Strapi v5 CMS with MySQL, deployed on Heroku
 - Dutch-only admin locale (`nl`)
 - pnpm package manager, frozen lockfile in CI
 - Node >=20.0.0 <=24.x.x
+- TypeScript for all source files (src/, config/)
 
 ## ANTI-PATTERNS (THIS PROJECT)
 - No custom controllers/services beyond factory boilerplate — all business logic is in the frontend

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Don't understand a word or term? Look it up in the [glossary](/documentation/glo
 ## Installation
 
 ```bash
-npm install
+pnpm install
 ```
 
 For detailed instructions and requirements, check out the [getting started docs](/documentation/getting-started.md).
@@ -33,7 +33,7 @@ For detailed instructions and requirements, check out the [getting started docs]
 ## Running locally
 
 ```bash
-npm run develop
+pnpm dev
 ```
 
 For detailed instructions, check out the [getting started docs](/documentation/getting-started.md#running-locally).
@@ -44,7 +44,7 @@ For detailed instructions, check out the [getting started docs](/documentation/g
 | :------------- | :------------------------------------------------------- | :-------------------------------------------------------- |
 | DNS            | [Cloudflare](https://www.cloudflare.com/) DNS management | DNS management with Cloudflare routing & DDoS protection. |
 | Frontend app   | Hosting on [Vercel](https://www.vercel.com)              | Dynamic hosting with CI/CD capabilities for FE app.       |
-| Backend CMS    | Hosting on [Heroku](https://www.heroku.com)              | Dynamic hosting with CI/CD capabilities for BE CMS.       |
+| Backend CMS    | Hosting on [Coolify](https://coolify.io)                 | Self-hosted Docker deployment with CI/CD.               |
 | Error tracking | [Sentry](https://www.sentry.com)                         | Error tracking in a Sentry dashboard.                     |
 
 For a detailed view and instructions, check out the [deployment docs](/documentation/deployment.md).

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -50,6 +50,39 @@ Errors will be collected in a [Sentry](https://www.sentry.com) dashboard.
 
 To be determined.
 
+## CI/CD Pipeline
+
+A GitHub Actions workflow is configured in `.github/workflows/ci.yml` to run on every push to `main` and on every pull request.
+
+**Build steps:**
+1. Check out the repository
+2. Install pnpm 11.5.0
+3. Set up Node.js 22
+4. Install dependencies (`pnpm install --frozen-lockfile`)
+5. Build the project (`pnpm build`)
+
+**Required build secrets:**
+The CI pipeline requires environment variables for the build. See the workflow file for the exact list.
+
+## Docker & Build Configuration
+
+### pnpm Workspace
+
+The project uses `pnpm-workspace.yaml` to configure pnpm-specific settings:
+
+- **allowBuilds**: Allows postinstall builds for native dependencies like `@swc/core`, `sharp`, `esbuild`
+- **overrides**: Pins specific dependency versions for compatibility
+
+This file must be included in the Docker build context alongside `package.json` and `pnpm-lock.yaml`.
+
+### Security Headers (CSP)
+
+The application configures custom Content Security Policy headers in `config/middlewares.js` to support:
+
+- [Cloudinary](https://cloudinary.com) for image uploads
+- [Google Maps](https://maps.google.com) for the maps plugin
+- [Strapi](https://strapi.io) market assets
+
 ## Environments
 
 This project consists of different environments, all of which having a different purpose.

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -1,7 +1,5 @@
 # Deployment
 
-TODO: write deployment manual
-
 ## Table of contents
 
 - [Resource providers](#resource-providers)
@@ -18,7 +16,7 @@ TODO: write deployment manual
 | :------------- | :-------------------------------------------------------- | :------------------------------------------------------------------------------- |
 | DNS            | [Cloudflare](https://cloudflare.com/) DNS management      | DNS management DDoS protection.                                                  |
 | Frontend app   | Hosting on [Vercel](https://www.vercel.app)               | Dynamic hosting with CI/CD capabilities for FE app.                              |
-| Backend CMS    | Hosting on [Heroku](https://www.heroku.com)               | Dynamic hosting with CI/CD capabilities for BE CMS.                              |
+| Backend CMS    | Hosting on [Coolify](https://coolify.io)                   | Self-hosted Docker deployment with CI/CD capabilities.                           |
 | Database       | MySQL database hosted on [Vimexx](https://www.vimexx.be/) | Both the development and production environments have a separate MySQL database. |
 | Error tracking | [Sentry](https://www.sentry.com)                          | Error tracking in a Sentry dashboard.                                            |
 | E-mail setup   | To be determined                                          | Check out the [e-mail setup docs](/documentation/e-mail-setup.md).               |
@@ -33,7 +31,16 @@ The website's frontend is a NextJS application and is hosted on [Vercel](https:/
 
 ### Backend hosting
 
-The website's backend CMS is a [Strapi](https://www.strapi.io) instance and is hosted on [Heroku](https://www.heroku.com). A CI/CD pipeline has been set up for automatic deployment when pushing changes and/or features to the `main` branch.
+The website's backend CMS is a [Strapi](https://www.strapi.io) instance and is hosted on [Coolify](https://coolify.io). The deployment is containerized using Docker and automatically deploys when changes are pushed to the `main` branch.
+
+#### Docker setup
+
+The project uses a multi-stage Dockerfile:
+
+- **Builder stage**: Installs dependencies using `pnpm` and builds the Strapi admin panel
+- **Runner stage**: Copies the built application and runs it in production mode
+
+Base image: `node:22-alpine` (required for pnpm 11.5.0 compatibility)
 
 ### Error tracking
 

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -14,8 +14,8 @@
 
 ## Requirements
 
-- [Node.js](https://nodejs.org) (v18.14.0)
-- [NPM](https://npmjs.com) (v6 and up)
+- [Node.js](https://nodejs.org) (>=20.0.0 <=24.x.x)
+- [pnpm](https://pnpm.io) (v11.5.0 or compatible)
 - [NVM](https://github.com/nvm-sh/nvm) (optional but recommended)
 - [MySQL](https://www.mysql.com) database (hosted, local or [Docker](https://www.docker.com/))
 
@@ -45,7 +45,7 @@
 5. Install dependencies
 
    ```bash
-   npm install
+   pnpm install
    ```
 
 ## Running locally
@@ -54,7 +54,7 @@
 2. Start the development server using
 
    ```bash
-   npm run develop
+   pnpm dev
    ```
 
 3. You can now visit the CMS admin panel on [port 1337](http://localhost:1337).
@@ -64,10 +64,10 @@
 ### Local build
 
 1. [Clone and install](#installation) this repo
-2. Produce a production build using `npm`
+2. Produce a production build using `pnpm`
 
    ```bash
-   npm run build
+   pnpm build
    ```
 
 ### Production build

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -84,6 +84,45 @@ For more info, check out the [deployment docs](/documentation/deployment.md).
 
 Instead of the traditional git-flow, this project is based on the [trunk based development](https://trunkbaseddevelopment.com/) principle.
 
+## Environment Variables
+
+The application requires the following environment variables to be set in the `.env` file:
+
+### Required Variables
+
+| Variable | Description | Example |
+| :------- | :---------- | :------ |
+| `APP_ENV` | Environment name (development/staging/production) | `development` |
+| `APP_KEYS` | Secret keys for application security | `key1,key2,key3,key4` |
+| `DB_HOST` | MySQL database host | `localhost` |
+| `DB_PORT` | MySQL database port | `3306` |
+| `DB_NAME` | MySQL database name | `scouting_lommel` |
+| `DB_USERNAME` | MySQL database user | `strapi` |
+| `DB_PASSWORD` | MySQL database password | `secret` |
+| `JWT_SECRET` | Secret for JWT token generation | `secret` |
+| `ADMIN_JWT_SECRET` | Secret for admin JWT tokens | `secret` |
+| `API_TOKEN_SALT` | Salt for API tokens | `salt` |
+| `TRANSFER_TOKEN_SALT` | Salt for data transfer tokens | `salt` |
+| `ENCRYPTION_KEY` | Key for encryption operations | `key` |
+
+### Cloudinary Variables (Optional)
+
+| Variable | Description | Example |
+| :------- | :---------- | :------ |
+| `CLOUDINARY_NAME` | Cloudinary cloud name | `scoutinglommel` |
+| `CLOUDINARY_KEY` | Cloudinary API key | `123456789` |
+| `CLOUDINARY_SECRET` | Cloudinary API secret | `secret` |
+
+## TypeScript
+
+This project is written in TypeScript. All source files in `src/` and `config/` use the `.ts` extension. The TypeScript configuration is defined in `tsconfig.json` with the following key settings:
+
+- **Module**: NodeNext
+- **Target**: ES2020
+- **Strict mode**: Disabled (for migration compatibility)
+
+When adding new API modules, use `.ts` files for controllers, services, and routes.
+
 ## Endpoints
 
 | Name                   | Description                                    | Endpoint                                                       |


### PR DESCRIPTION
## Changes

- **README.md**: Updated npm references to pnpm, changed deployment platform from Heroku to Coolify
- **documentation/getting-started.md**: Updated Node.js version requirements (>=20.0.0 <=24.x.x), changed npm to pnpm in all commands
- **documentation/deployment.md**: Removed TODO, updated backend hosting from Heroku to Coolify, added Docker setup section
- **AGENTS.md**: Updated file references from .js to .ts, added TypeScript convention
- **src/api/AGENTS.md**: Updated file references from .js to .ts, added TypeScript convention

## Why

Documentation was outdated after the migration to TypeScript and the switch to pnpm and Coolify for deployment.